### PR TITLE
fix(shadow-box): 修复通过角度和distance返回坐标的bug

### DIFF
--- a/app/manager/box.shadow.manager/box.shadow.manager.ts
+++ b/app/manager/box.shadow.manager/box.shadow.manager.ts
@@ -98,11 +98,11 @@ export class BoxShadowManager implements BoxShadowManagerInterface {
     angle: number,
     distance: number
   ): {
-      horizontal: number;
-      vertical: number;
-      positionX: number;
-      positionY: number;
-    } {
+    horizontal: number;
+    vertical: number;
+    positionX: number;
+    positionY: number;
+  } {
     // 弧度转角度 1弧度=180/π度，1度=π/180弧度
     const newAngel = (angle * Math.PI) / 180;
     const sin = Math.sin(newAngel);
@@ -125,10 +125,23 @@ export class BoxShadowManager implements BoxShadowManagerInterface {
       positionX = this.#radius!;
       positionY = 0;
     }
+    positionY = -positionY;
     const horizontal = (positionX * distance) / this.#radius!;
     const vertical = (positionY * distance) / this.#radius!;
-    positionX = positionX + this.#radius! - this.#pointRadius!;
-    positionY = positionY + this.#radius! - this.#pointRadius!;
+    // 先转移整体坐标系
+    positionX += this.#radius!;
+    positionY += this.#radius!;
+    // 针对小红点，做坐标调整
+    // 小红点圆心坐标
+    const pointCenterX =
+      (this.#pointRadius! / this.#radius!) * (positionX - this.#radius!) +
+      this.#radius!;
+    const pointCenterY =
+      (this.#pointRadius! / this.#radius!) * (positionY - this.#radius!) +
+      this.#radius!;
+    // 求助小红点所在正方形的左上角坐标
+    positionX = pointCenterX - this.#pointRadius!;
+    positionY = pointCenterY - this.#pointRadius!;
     return {
       horizontal,
       vertical,


### PR DESCRIPTION
bug原因
1、有一处positionY应该取负值的代码被误删了，导致positionY计算错误。
2、在根据圆点半径调整坐标时，不可以简单的减去小圆点半径，要先计算小圆点的圆心，然后再偏移半径的距离，得到小圆点所在正方形的左上角坐标。